### PR TITLE
feat!: add deno runner and change default runner from job to deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ vim.g.neoquickrun_config = {
 
 | Runner | Description | Requirements |
 |--------|-------------|--------------|
-| **deno** | Asynchronous execution using `Deno.Command` (default) | None |
-| **system** | Synchronous execution using `Deno.Command` | None |
+| **deno** | Asynchronous execution using `Deno.Command` (default) | Deno `--allow-run` (granted by denops) |
+| **system** | Synchronous execution using `Deno.Command` | Deno `--allow-run` (granted by denops) |
 | **job** | Asynchronous execution using Vim's job feature | `+job` |
 | **terminal** | Execute in terminal window | `+terminal` |
 | **shell** | Execute using `:!` command | None |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A modern, TypeScript-based reimplementation of [vim-quickrun](https://github.com
 ## ✨ Features
 
 - **⚡ Fast Execution** - Execute code snippets and files instantly
-- **🎯 Multiple Runners** - System, Job, Terminal, Shell, Remote, Vimscript
+- **🎯 Multiple Runners** - Deno, System, Job, Terminal, Shell, Remote, Vimscript
 - **📤 Flexible Output** - Buffer, Quickfix, Float (Neovim), Browser, and more
 - **🪝 Extensible Hooks** - Modify behavior with pre/post execution hooks
 - **🔧 Highly Configurable** - Customize execution per filetype
@@ -67,7 +67,7 @@ call dein#add('aiya000/vim-neoquickrun')
     -- Configuration for neoquickrun.vim (optional)
     vim.g.neoquickrun_config = {
       _ = {
-        runner = 'job',
+        runner = 'deno',
         outputter = 'buffer',
       },
       python = {
@@ -103,7 +103,7 @@ Execute current buffer:
 Execute with specific runner:
 
 ```vim
-:NeoQuickRun -runner job
+:NeoQuickRun -runner deno
 ```
 
 Execute Python code:
@@ -132,7 +132,7 @@ nmap <Leader>o <Plug>(neoquickrun-op)
 ```vim
 let g:neoquickrun_config = {
   \ '_': {
-    \ 'runner': 'job',
+    \ 'runner': 'deno',
     \ 'outputter': 'buffer',
   \ },
   \ 'python': {
@@ -153,7 +153,7 @@ let g:neoquickrun_config = {
 ```lua
 vim.g.neoquickrun_config = {
   _ = {
-    runner = 'job',
+    runner = 'deno',
     outputter = 'buffer',
   },
   python = {
@@ -175,6 +175,7 @@ vim.g.neoquickrun_config = {
 
 | Runner | Description | Requirements |
 |--------|-------------|--------------|
+| **deno** | Asynchronous execution using `Deno.Command` (default) | None |
 | **system** | Synchronous execution using `Deno.Command` | None |
 | **job** | Asynchronous execution using Vim's job feature | `+job` |
 | **terminal** | Execute in terminal window | `+terminal` |
@@ -276,7 +277,7 @@ vim.g.neoquickrun_config = {
 ```vim
 let g:neoquickrun_config = {
   \ '_': {
-    \ 'runner': 'job',
+    \ 'runner': 'deno',
     \ 'outputter': 'buffer',
   \ },
 \ }
@@ -287,7 +288,7 @@ let g:neoquickrun_config = {
 ```lua
 vim.g.neoquickrun_config = {
   _ = {
-    runner = 'job',
+    runner = 'deno',
     outputter = 'buffer',
   },
 }
@@ -314,7 +315,7 @@ vim.b.neoquickrun_config = {
 ### Command-Line Options
 
 ```vim
-:NeoQuickRun -runner job -outputter quickfix
+:NeoQuickRun -runner deno -outputter quickfix
 ```
 
 ---

--- a/denops/neoquickrun/config.ts
+++ b/denops/neoquickrun/config.ts
@@ -13,7 +13,7 @@ import { deepMerge, merge } from './utils/functional.ts'
  */
 export const DEFAULT_CONFIG: Config = {
   outputter: 'buffer',
-  runner: 'job',
+  runner: 'deno',
   cmdopt: '',
   args: '',
   tempfile: '%{tempname()}',

--- a/denops/neoquickrun/main.ts
+++ b/denops/neoquickrun/main.ts
@@ -54,7 +54,7 @@ export const main = (denops: Denops): void => {
         let context = createContext(denops, config, src, srcfile)
 
         // Get runner, outputter, and hooks
-        const runnerName = config.runner || 'job'
+        const runnerName = config.runner || 'deno'
         const outputterName = config.outputter || 'buffer'
 
         const runner = await getRunner(runnerName, config)

--- a/denops/neoquickrun/runner/deno.ts
+++ b/denops/neoquickrun/runner/deno.ts
@@ -1,0 +1,157 @@
+/**
+ * Deno runner - execute commands using Deno.Command
+ */
+
+import type { Config, ExecutionContext, ExecutionResult, Runner } from '../types.ts'
+import type { Denops } from 'https://deno.land/x/denops_std@v6.5.0/mod.ts'
+
+/**
+ * Create deno runner
+ */
+export const createDenoRunner = (_config: Config): Runner => {
+  return {
+    name: 'deno',
+    validate: async (_denops: Denops) => {
+      // Deno runner is always available
+    },
+    run: async (
+      _context: ExecutionContext,
+      commands: readonly string[],
+      input: string
+    ): Promise<ExecutionResult> => {
+      let output = ''
+      let exitCode = 0
+
+      for (const command of commands) {
+        const result = await executeCommand(command, input)
+        output += result.output
+        exitCode = result.exitCode
+
+        // If command fails, stop execution
+        if (exitCode !== 0) {
+          break
+        }
+
+        // Use output as input for next command
+        input = result.output
+      }
+
+      return {
+        output,
+        exitCode,
+        success: exitCode === 0,
+      }
+    },
+  }
+}
+
+/**
+ * Execute a single command
+ */
+const executeCommand = async (
+  command: string,
+  input: string
+): Promise<{ output: string; exitCode: number }> => {
+  try {
+    // Parse command and arguments
+    const args = parseCommand(command)
+    if (args.length === 0) {
+      return { output: '', exitCode: 1 }
+    }
+
+    const cmd = args[0] as string
+    const cmdArgs = args.slice(1)
+
+    // Create command
+    const process = new Deno.Command(cmd, {
+      args: cmdArgs,
+      stdin: 'piped',
+      stdout: 'piped',
+      stderr: 'piped',
+    })
+
+    // Spawn process
+    const child = process.spawn()
+
+    // Write input to stdin
+    const writer = child.stdin.getWriter()
+    await writer.write(new TextEncoder().encode(input))
+    await writer.close()
+
+    // Wait for completion
+    const { code, stdout, stderr } = await child.output()
+
+    // Combine stdout and stderr
+    const outputText = new TextDecoder().decode(stdout)
+    const errorText = new TextDecoder().decode(stderr)
+    const output = outputText + errorText
+
+    return {
+      output,
+      exitCode: code,
+    }
+  } catch (error) {
+    return {
+      output: `Error executing command: ${error}`,
+      exitCode: 1,
+    }
+  }
+}
+
+/**
+ * Parse command string into command and arguments
+ * Simple shell-like parsing
+ */
+const parseCommand = (command: string): string[] => {
+  const args: string[] = []
+  let current = ''
+  let inQuote: "'" | '"' | null = null
+  let escaped = false
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i]
+
+    if (!char) continue
+
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+
+    if (inQuote) {
+      if (char === inQuote) {
+        inQuote = null
+      } else {
+        current += char
+      }
+      continue
+    }
+
+    if (char === "'" || char === '"') {
+      inQuote = char
+      continue
+    }
+
+    if (char === ' ' || char === '\t') {
+      if (current) {
+        args.push(current)
+        current = ''
+      }
+      continue
+    }
+
+    current += char
+  }
+
+  if (current) {
+    args.push(current)
+  }
+
+  return args
+}

--- a/denops/neoquickrun/runner/mod.ts
+++ b/denops/neoquickrun/runner/mod.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Config } from '../types.ts'
-import { registerRunner, getRunner } from './types.ts'
+import { registerRunner } from './types.ts'
 import { createDenoRunner } from './deno.ts'
 import { createSystemRunner } from './system.ts'
 import { createJobRunner } from './job.ts'

--- a/denops/neoquickrun/runner/mod.ts
+++ b/denops/neoquickrun/runner/mod.ts
@@ -4,6 +4,7 @@
 
 import type { Config } from '../types.ts'
 import { registerRunner, getRunner } from './types.ts'
+import { createDenoRunner } from './deno.ts'
 import { createSystemRunner } from './system.ts'
 import { createJobRunner } from './job.ts'
 import { createTerminalRunner } from './terminal.ts'
@@ -15,6 +16,7 @@ import { createVimscriptRunner } from './vimscript.ts'
  * Initialize all runners
  */
 export const initializeRunners = (): void => {
+  registerRunner('deno', async (config: Config) => createDenoRunner(config))
   registerRunner('system', async (config: Config) =>
     createSystemRunner(config)
   )

--- a/doc/neoquickrun.txt
+++ b/doc/neoquickrun.txt
@@ -132,7 +132,7 @@ You can override these defaults in your .vimrc:
 >vim
   let g:neoquickrun_config = {
     \ '_': {
-      \ 'runner': 'job',
+      \ 'runner': 'deno',
       \ 'outputter': 'buffer',
       \ 'exec': '%c %o %s %a',
       \ 'tempfile': '%{tempname()}',
@@ -181,7 +181,7 @@ For Neovim users, you can configure vim-neoquickrun using Lua:
 >lua
   vim.g.neoquickrun_config = {
     _ = {
-      runner = 'job',
+      runner = 'deno',
       outputter = 'buffer',
       exec = '%c %o %s %a',
       tempfile = '%{tempname()}',
@@ -465,7 +465,7 @@ Example:
   " Use system runner
   :NeoQuickRun -runner system
 <
-Default: `'job'`
+Default: `'deno'`
 
 ------------
 ### *neoquickrun-option-hooks*
@@ -612,7 +612,7 @@ Example:
 >vim
   let g:neoquickrun_config = {
     \ '_': {
-      \ 'runner': 'job',
+      \ 'runner': 'deno',
       \ 'outputter': 'buffer',
     \ },
     \ 'python': {
@@ -676,6 +676,12 @@ Runner is a module to execute programs.
 The following runners are available:
 
 ---------------
+#### runner/deno *neoquickrun-module-runner/deno*
+
+Runs by Deno's |Deno.Command| API asynchronously.
+This is the default runner.
+
+---------------
 #### runner/system *neoquickrun-module-runner/system*
 
 Runs by Deno's subprocess API synchronously.
@@ -684,7 +690,6 @@ Runs by Deno's subprocess API synchronously.
 #### runner/job *neoquickrun-module-runner/job*
 
 Runs via Vim/Neovim's |job| feature asynchronously.
-This is the default runner.
 
 ---------------
 #### runner/terminal *neoquickrun-module-runner/terminal*


### PR DESCRIPTION
## Summary

- `runner/deno.ts` を新規作成（`Deno.Command` ベース、現 `system` runner の実装を移植）
- `DEFAULT_CONFIG.runner` を `'job'` → `'deno'` に変更（Neovim で発生していた `Job feature is not available` エラーの修正）
- `main.ts` のフォールバックも `'deno'` に変更
- `runner/mod.ts` に `deno` runner を登録
- `README.md` / `doc/neoquickrun.txt` を更新

## Motivation

Neovim では `has('job')` が `0` を返すため、`job` runner をデフォルトにしていると「Job feature is not available」エラーが発生していた。`Deno.Command` ベースの `deno` runner をデフォルトにすることで Vim/Neovim 両対応になる。

## Test plan

- [ ] Neovim で `.ts` ファイルを開き `<leader>r` で実行できる
- [ ] `runner = 'deno'` を明示指定しても動作する
- [ ] `runner = 'job'` を指定すれば従来の job runner も使える（まだ削除していない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)