### PR TITLE
feat: add lua runner for neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A modern, TypeScript-based reimplementation of [vim-quickrun](https://github.com
 ## ✨ Features
 
 - **⚡ Fast Execution** - Execute code snippets and files instantly
-- **🎯 Multiple Runners** - Deno, System, Terminal, Shell, Remote, Vimscript
+- **🎯 Multiple Runners** - Deno, System, Lua, Terminal, Shell, Remote, Vimscript
 - **📤 Flexible Output** - Buffer, Quickfix, Float (Neovim), Browser, and more
 - **🪝 Extensible Hooks** - Modify behavior with pre/post execution hooks
 - **🔧 Highly Configurable** - Customize execution per filetype
@@ -177,6 +177,7 @@ vim.g.neoquickrun_config = {
 |--------|-------------|--------------|
 | **deno** | Asynchronous execution using `Deno.Command` (default) | None |
 | **system** | Synchronous execution using Vim's `system()` (blocks Vim during execution) | None |
+| **lua** | Execute Lua code via `nvim_exec2` (Neovim only) | Neovim |
 | **terminal** | Execute in terminal window | `+terminal` |
 | **shell** | Execute using `:!` command | None |
 | **remote** | Background execution using clientserver | `+clientserver` |

--- a/denops/neoquickrun/runner/lua.ts
+++ b/denops/neoquickrun/runner/lua.ts
@@ -1,0 +1,67 @@
+/**
+ * Lua runner - execute Lua code using Neovim's nvim_exec2
+ */
+
+import type { Config, ExecutionContext, ExecutionResult, Runner } from '../types.ts'
+import type { Denops } from 'https://deno.land/x/denops_std@v6.5.0/mod.ts'
+
+/**
+ * Create lua runner
+ */
+export const createLuaRunner = (_config: Config): Runner => {
+  return {
+    name: 'lua',
+    validate: async (denops: Denops) => {
+      const hasNvim = await denops.call('has', 'nvim')
+      if (!hasNvim) {
+        throw new Error('Lua runner requires Neovim')
+      }
+    },
+    run: async (
+      context: ExecutionContext,
+      commands: readonly string[],
+      _input: string
+    ): Promise<ExecutionResult> => {
+      let output = ''
+      let exitCode = 0
+
+      for (const command of commands) {
+        const result = await executeLua(context.denops, command)
+        output += result.output
+        exitCode = result.exitCode
+
+        // If command fails, stop execution
+        if (exitCode !== 0) {
+          break
+        }
+      }
+
+      return {
+        output,
+        exitCode,
+        success: exitCode === 0,
+      }
+    },
+  }
+}
+
+/**
+ * Execute Lua code using nvim_exec2
+ */
+const executeLua = async (
+  denops: Denops,
+  command: string
+): Promise<{ output: string; exitCode: number }> => {
+  try {
+    const result = (await denops.call('nvim_exec2', command, {
+      output: true,
+    })) as { output?: string }
+    const output = result.output ?? ''
+    return { output, exitCode: 0 }
+  } catch (error) {
+    return {
+      output: `Error executing Lua: ${error}`,
+      exitCode: 1,
+    }
+  }
+}

--- a/denops/neoquickrun/runner/lua_test.ts
+++ b/denops/neoquickrun/runner/lua_test.ts
@@ -1,0 +1,7 @@
+import { assertEquals } from 'jsr:@std/assert'
+import { createLuaRunner } from './lua.ts'
+
+Deno.test('createLuaRunner - name is lua', () => {
+  const runner = createLuaRunner({})
+  assertEquals(runner.name, 'lua')
+})

--- a/denops/neoquickrun/runner/mod.ts
+++ b/denops/neoquickrun/runner/mod.ts
@@ -6,6 +6,7 @@ import type { Config } from '../types.ts'
 import { registerRunner, getRunner } from './types.ts'
 import { createDenoRunner } from './deno.ts'
 import { createSystemRunner } from './system.ts'
+import { createLuaRunner } from './lua.ts'
 import { createTerminalRunner } from './terminal.ts'
 import { createShellRunner } from './shell.ts'
 import { createRemoteRunner } from './remote.ts'
@@ -19,6 +20,7 @@ export const initializeRunners = (): void => {
   registerRunner('system', async (config: Config) =>
     createSystemRunner(config)
   )
+  registerRunner('lua', async (config: Config) => createLuaRunner(config))
   registerRunner('terminal', async (config: Config) =>
     createTerminalRunner(config)
   )

--- a/doc/neoquickrun.txt
+++ b/doc/neoquickrun.txt
@@ -688,6 +688,12 @@ Runs by Vim's |system()| function synchronously.
 Blocks Vim during execution.
 
 ---------------
+#### runner/lua *neoquickrun-module-runner/lua*
+
+Runs Lua code via Neovim's |nvim_exec2()| function.
+Neovim only.
+
+---------------
 #### runner/terminal *neoquickrun-module-runner/terminal*
 
 Runs commands in terminal window via |terminal| feature.


### PR DESCRIPTION
## Summary

- `runner/lua.ts` を新規作成（`nvim_exec2` ベース、Neovim 専用）
- `runner/lua_test.ts` を新規作成（`name` プロパティのユニットテスト）
- `runner/mod.ts` に `lua` runner を登録
- `README.md` / `doc/neoquickrun.txt` に `lua` runner の説明を追加

## Motivation

Neovim 上で Lua コードをインタラクティブに実行する runner を追加する。`nvim_exec2()` を使って実行し、`output` フィールドから結果をキャプチャする。

## Test plan

- [ ] `runner = 'lua'` 指定時に Neovim 上で Lua が実行される
- [ ] `runner = 'lua'` を Vim で指定したときに「Lua runner requires Neovim」エラーになる
- [ ] `deno test --allow-all` でユニットテストが通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)